### PR TITLE
Fix worktree DB-create path when DB user equals DB name

### DIFF
--- a/plugins/create-worktree-friendly/skills/create-worktree-friendly/templates/with-worktree-db.drizzle.sh
+++ b/plugins/create-worktree-friendly/skills/create-worktree-friendly/templates/with-worktree-db.drizzle.sh
@@ -33,12 +33,28 @@ else
   DB="${DB_NAME_BASE}_${SUFFIX}"
 fi
 
+# Swap the database (the last path segment) of a Postgres URL, preserving
+# user / password / host / port and any ?query string.
+#
+# We deliberately do NOT do a blanket `${url//\/$old/\/$new}` replace: when
+# the DB name also appears as the username (e.g. user=app, db=app) that
+# pattern matches the `//` in `postgresql://app...` and corrupts the
+# username. Splitting on the final `/` only touches the DB segment.
+swap_db() {
+  local url="$1" newdb="$2" base query
+  case "$url" in
+    *\?*) base="${url%%\?*}"; query="?${url#*\?}";;
+    *)    base="$url";        query="";;
+  esac
+  printf '%s/%s%s' "${base%/*}" "$newdb" "$query"
+}
+
 ORIG_URL=$(grep -E "^DATABASE_URL=" {{ENV_TEST_FILE}} 2>/dev/null | head -1 | cut -d= -f2-)
 if [ -z "${ORIG_URL:-}" ]; then
   echo "with-worktree-db: DATABASE_URL not found in {{ENV_TEST_FILE}}" >&2
   exit 1
 fi
-NEW_URL="${ORIG_URL//\/${DB_NAME_BASE}/\/${DB}}"
+NEW_URL="$(swap_db "$ORIG_URL" "$DB")"
 export DATABASE_URL="$NEW_URL"
 
 # Probe + auto-create. Drizzle ships no equivalent of `prisma db execute`,
@@ -47,7 +63,7 @@ export DATABASE_URL="$NEW_URL"
 JUST_CREATED=0
 if ! psql "$NEW_URL" -c "SELECT 1" >/dev/null 2>&1; then
   echo "[worktree-db] $DB not reachable — attempting to create..."
-  ADMIN_URL="${NEW_URL//\/${DB}/\/postgres}"
+  ADMIN_URL="$(swap_db "$NEW_URL" postgres)"
   if ! psql "$ADMIN_URL" -c "CREATE DATABASE \"$DB\"" >/dev/null 2>&1; then
     echo "[worktree-db] failed to create $DB. Is psql installed and Postgres up?" >&2
     exit 1

--- a/plugins/create-worktree-friendly/skills/create-worktree-friendly/templates/with-worktree-db.prisma.sh
+++ b/plugins/create-worktree-friendly/skills/create-worktree-friendly/templates/with-worktree-db.prisma.sh
@@ -44,6 +44,22 @@ else
   DB="${DB_NAME_BASE}_${SUFFIX}"
 fi
 
+# Swap the database (the last path segment) of a Postgres URL, preserving
+# user / password / host / port and any ?query string.
+#
+# We deliberately do NOT do a blanket `${url//\/$old/\/$new}` replace: when
+# the DB name also appears as the username (e.g. user=app, db=app) that
+# pattern matches the `//` in `postgresql://app...` and corrupts the
+# username. Splitting on the final `/` only touches the DB segment.
+swap_db() {
+  local url="$1" newdb="$2" base query
+  case "$url" in
+    *\?*) base="${url%%\?*}"; query="?${url#*\?}";;
+    *)    base="$url";        query="";;
+  esac
+  printf '%s/%s%s' "${base%/*}" "$newdb" "$query"
+}
+
 # Compose DATABASE_URL by swapping the database name in the URL from
 # {{ENV_TEST_FILE}}. Preserves user / password / host / port / query params.
 ORIG_URL=$(grep -E "^DATABASE_URL=" {{ENV_TEST_FILE}} 2>/dev/null | head -1 | cut -d= -f2-)
@@ -51,11 +67,11 @@ if [ -z "${ORIG_URL:-}" ]; then
   echo "with-worktree-db: DATABASE_URL not found in {{ENV_TEST_FILE}}" >&2
   exit 1
 fi
-NEW_URL="${ORIG_URL//\/${DB_NAME_BASE}/\/${DB}}"
+NEW_URL="$(swap_db "$ORIG_URL" "$DB")"
 
 ORIG_UNPOOLED=$(grep -E "^DATABASE_URL_UNPOOLED=" {{ENV_TEST_FILE}} 2>/dev/null | head -1 | cut -d= -f2- || true)
 if [ -n "${ORIG_UNPOOLED:-}" ]; then
-  NEW_UNPOOLED="${ORIG_UNPOOLED//\/${DB_NAME_BASE}/\/${DB}}"
+  NEW_UNPOOLED="$(swap_db "$ORIG_UNPOOLED" "$DB")"
   export DATABASE_URL_UNPOOLED="$NEW_UNPOOLED"
 fi
 
@@ -65,8 +81,8 @@ export DATABASE_URL="$NEW_URL"
 JUST_CREATED=0
 if ! DATABASE_URL="$NEW_URL" DATABASE_URL_UNPOOLED="${NEW_UNPOOLED:-$NEW_URL}" npx --no-install prisma db execute --schema prisma/schema.prisma --stdin <<<"SELECT 1" >/dev/null 2>&1; then
   echo "[worktree-db] $DB not reachable — attempting to create..."
-  ADMIN_URL="${NEW_URL//\/${DB}/\/postgres}"
-  ADMIN_UNPOOLED="${NEW_UNPOOLED//\/${DB}/\/postgres}"
+  ADMIN_URL="$(swap_db "$NEW_URL" postgres)"
+  ADMIN_UNPOOLED="$(swap_db "${NEW_UNPOOLED:-$NEW_URL}" postgres)"
   if ! DATABASE_URL="$ADMIN_URL" DATABASE_URL_UNPOOLED="${ADMIN_UNPOOLED:-$ADMIN_URL}" npx --no-install prisma db execute --schema prisma/schema.prisma --stdin <<<"CREATE DATABASE \"$DB\""; then
     echo "[worktree-db] failed to create $DB. Check that Postgres is up." >&2
     exit 1


### PR DESCRIPTION
## Problem

The generated `with-worktree-db.sh` wrappers rewrote the database name in `DATABASE_URL` with a blanket replace:

```sh
NEW_URL="${ORIG_URL//\/${DB_NAME_BASE}/\/${DB}}"
```

When the DB **user** and DB **name** are the same (e.g. `user=app`, `db=app`), the pattern `/app` also matches the `//` in `postgresql://app...`, corrupting the **username**. The auto-create path then derives the admin URL by swapping the (already-wrong) name to `postgres`, so it connects as user `postgres` and fails authentication:

```
[worktree-db] <db> not reachable — attempting to create...
Authentication failed against database server at `localhost`,
the provided database credentials for `postgres` are not valid.
[worktree-db] failed to create <db>.
```

This never triggers in the main checkout (its DB already exists, so the create path is skipped). It only surfaces the **first time a real worktree auto-creates its DB** — exactly the workflow this kit exists to enable. Found while bootstrapping a Next.js + Prisma repo whose docker-compose uses `user=vitalcopy` / `db=vitalcopy`.

## Fix

Replace the blanket replace in both the `prisma` and `drizzle` templates with a `swap_db` helper that rewrites only the final path segment, preserving user / password / host / port and any `?query` string.

Verified against the collision case, query strings, and Neon-style hostnames:

| input | new db | result |
|---|---|---|
| `…@localhost:5433/vitalcopy` (user=vitalcopy) | `vitalcopy_wt_test` | `…@localhost:5433/vitalcopy_wt_test` ✅ user intact |
| `…/vitalcopy_wt_test` | `postgres` | `…/postgres` ✅ user intact |
| `…/app?schema=public&sslmode=require` | `app_foo` | `…/app_foo?schema=public&sslmode=require` ✅ query intact |
| `…neon.tech/maindb?sslmode=require` | `maindb_x` | `…neon.tech/maindb_x?sslmode=require` ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)